### PR TITLE
chore: copy mariadb:10.7.1 to quay.io

### DIFF
--- a/utils/copyImagesToQuay.txt
+++ b/utils/copyImagesToQuay.txt
@@ -4,7 +4,7 @@
 
 docker.io/centos/mongodb-36-centos7
 docker.io/centos/mysql-57-centos7
-docker.io/mariadb:10.7
+docker.io/mariadb:10.7.1
 # registries use :latest, operator csv uses :9.6
 #docker.io/centos/postgresql-96-centos7
 #docker.io/centos/postgresql-96-centos7:9.6

--- a/utils/copyImagesToQuay.txt
+++ b/utils/copyImagesToQuay.txt
@@ -4,6 +4,7 @@
 
 docker.io/centos/mongodb-36-centos7
 docker.io/centos/mysql-57-centos7
+docker.io/mariadb:10.7
 # registries use :latest, operator csv uses :9.6
 #docker.io/centos/postgresql-96-centos7
 #docker.io/centos/postgresql-96-centos7:9.6


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

Need to copy mariadb:10.7.1 image to quay.io as it's required for https://github.com/che-samples/java-spring-petclinic/pull/9
