### PR TITLE
fix: restore e2e image check before phase 3

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -194,6 +194,7 @@ fi
 wait
 
 # shellcheck disable=SC2086
+verifyContainerExistsWithTimeout ${REGISTRY}/${ORGANIZATION}/che-e2e:${CHE_VERSION} 30
 verifyContainerExistsWithTimeout ${REGISTRY}/${ORGANIZATION}/che-plugin-registry:${CHE_VERSION} 30
 # Release devfile registry (depends on plugin registry)
 if [[ ${PHASES} == *"3"* ]]; then


### PR DESCRIPTION
Restore image existence verification for 'che-e2e' release job
Seems like it was accidentally removed with [this commit](https://github.com/eclipse-che/che-release/commit/a8211931d6a958be266711a77859de0de548b1ba#diff-be36842270d47fd0f7dd297abbdf5c5ef7916efe78fd4617f5ca6a5fdcba421cL214)
So adding it back, so that the orchestrator job would fail properly, when jobs for a certain phase didn't produce respective image

related issue: https://github.com/eclipse/che/issues/22273