### PR TITLE
feat: add devworkspace-generator to the release orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Currently there are several phases, representing an order of projects, which we 
 * Phase 2:
   * [che-e2e](https://github.com/eclipse/che) - depends on devworkspace-generator, che-server (typescript dto)
   * [che-plugin-registry](https://github.com/eclipse-che/che-plugin-registry) - depends on che-machine-exec
+  * [che-dashboard](https://github.com/eclipse-che/che-dashboard) - depends on devworkspace-generator
 
 * Phase 3:
   * [che-devfile-registry](https://github.com/eclipse-che/che-devfile-registry) - depends on plugin-registry, devworkspace-generator

--- a/README.md
+++ b/README.md
@@ -57,18 +57,18 @@ Currently there are several phases, representing an order of projects, which we 
 * Phase 1:
   * [che-code](https://github.com/che-incubator/che-code), 
   * [che-machine-exec](https://github.com/eclipse-che/che-machine-exec), 
-  * [che-dashboard](https://github.com/eclipse-che/che-dashboard), 
   * [che-server](https://github.com/eclipse-che/che-server);
+  * [devworkspace-generator](https://github.com/eclipse-che/che-devfile-registry/tree/main/tools/devworkspace-generator)
 * then creation of branches for:
   * [configbump](https://github.com/che-incubator/configbump),
   * [kubernetes-image-puller](https://github.com/che-incubator/kubernetes-image-puller)
 
 * Phase 2:
-  * [che-e2e](https://github.com/eclipse/che), 
-  * [che-plugin-registry](https://github.com/eclipse-che/che-plugin-registry)
+  * [che-e2e](https://github.com/eclipse/che) - depends on devworkspace-generator, che-server (typescript dto)
+  * [che-plugin-registry](https://github.com/eclipse-che/che-plugin-registry) - depends on che-machine-exec
 
 * Phase 3:
-  * [che-devfile-registry](https://github.com/eclipse-che/che-devfile-registry)
+  * [che-devfile-registry](https://github.com/eclipse-che/che-devfile-registry) - depends on plugin-registry, devworkspace-generator
 
 * Phase 4:
   * [che-operator](https://github.com/eclipse-che/che-operator) - depends on phases 1 to 3 and performs several e2e validation tests

--- a/make-release.sh
+++ b/make-release.sh
@@ -187,7 +187,7 @@ verifyBranchExistsWithTimeoutAndExit "https://github.com/che-incubator/configbum
 # shellcheck disable=SC2086
 verifyBranchExistsWithTimeoutAndExit "https://github.com/che-incubator/kubernetes-image-puller.git" ${BRANCH} 60
 # shellcheck disable=SC2086
-verifyNpmJsPackageExistsWithTimeoutAndExit "@eclipse-che/che-devworkspace-generator@7.70.0" 60
+verifyNpmJsPackageExistsWithTimeoutAndExit "@eclipse-che/che-devworkspace-generator@${CHE_VERSION}" 60
 set +x
 # Release e2e (depends on che-server, devworkspace-generator)
 # Release plugin registry (depends on machine-exec)

--- a/make-release.sh
+++ b/make-release.sh
@@ -186,7 +186,8 @@ verifyContainerExistsWithTimeout ${REGISTRY}/${ORGANIZATION}/che-server:${CHE_VE
 verifyBranchExistsWithTimeoutAndExit "https://github.com/che-incubator/configbump.git" ${BRANCH} 60
 # shellcheck disable=SC2086
 verifyBranchExistsWithTimeoutAndExit "https://github.com/che-incubator/kubernetes-image-puller.git" ${BRANCH} 60
-
+# shellcheck disable=SC2086
+verifyNpmJsPackageExistsWithTimeoutAndExit "@eclipse-che/che-devworkspace-generator@7.70.0" 60
 set +x
 # Release e2e (depends on che-server, devworkspace-generator)
 # Release plugin registry (depends on machine-exec)

--- a/make-release.sh
+++ b/make-release.sh
@@ -14,8 +14,8 @@ usage ()
   echo "Usage: $0  --version [CHE VERSION TO RELEASE] --parent-version [CHE PARENT VERSION] --phases [LIST OF PHASES]
 
 # Comma-separated phases to perform.
-#1: Code, MachineExec, Dashboard, Server, createBranches;
-#2: E2E, PluginRegistry;
+#1: Code, MachineExec, Server, createBranches;
+#2: E2E, PluginRegistry, Dashboard;
 #3: DevfileRegistry;
 #4: Operator;
 # Default: 1,2,3,4
@@ -87,6 +87,11 @@ releaseMachineExec() {
 
 releaseCheCode() {
     invokeAction che-incubator/che-code "Release Che Code" "34764281" "version=${CHE_VERSION}"
+}
+
+
+releaseDevworkspaceGenerator() {
+    invokeAction eclipse-che/che-devfile-registry "Release Che Devworkspace Generator" "TODO->WORKFLOW-ID" "version=${CHE_VERSION}"
 }
 
 releaseDevfileRegistry() {
@@ -168,6 +173,7 @@ if [[ ${PHASES} == *"1"* ]]; then
     releaseMachineExec
     releaseDashboard
     releaseCheServer
+    releaseDevworkspaceGenerator
     createBranches
 fi
 wait
@@ -185,7 +191,7 @@ verifyBranchExistsWithTimeoutAndExit "https://github.com/che-incubator/configbum
 verifyBranchExistsWithTimeoutAndExit "https://github.com/che-incubator/kubernetes-image-puller.git" ${BRANCH} 60
 
 set +x
-# Release e2e (depends on dashboard)
+# Release e2e (depends on che-server, devworkspace-generator)
 # Release plugin registry (depends on machine-exec)
 if [[ ${PHASES} == *"2"* ]]; then
     releaseCheE2E

--- a/make-release.sh
+++ b/make-release.sh
@@ -91,7 +91,7 @@ releaseCheCode() {
 
 
 releaseDevworkspaceGenerator() {
-    invokeAction eclipse-che/che-devfile-registry "Release Che Devworkspace Generator" "TODO->WORKFLOW-ID" "version=${CHE_VERSION}"
+    invokeAction eclipse-che/che-devfile-registry "Release Che Devworkspace Generator" "67742638" "version=${CHE_VERSION}"
 }
 
 releaseDevfileRegistry() {

--- a/make-release.sh
+++ b/make-release.sh
@@ -14,7 +14,7 @@ usage ()
   echo "Usage: $0  --version [CHE VERSION TO RELEASE] --parent-version [CHE PARENT VERSION] --phases [LIST OF PHASES]
 
 # Comma-separated phases to perform.
-#1: Code, MachineExec, Server, createBranches;
+#1: Code, MachineExec, Server, devworkspace-generator, createBranches;
 #2: E2E, PluginRegistry, Dashboard;
 #3: DevfileRegistry;
 #4: Operator;
@@ -171,7 +171,6 @@ set +x
 if [[ ${PHASES} == *"1"* ]]; then
     releaseCheCode
     releaseMachineExec
-    releaseDashboard
     releaseCheServer
     releaseDevworkspaceGenerator
     createBranches
@@ -181,8 +180,6 @@ wait
 verifyContainerExistsWithTimeout ${REGISTRY}/che-incubator/che-code:${CHE_VERSION} 60
 # shellcheck disable=SC2086
 verifyContainerExistsWithTimeout ${REGISTRY}/${ORGANIZATION}/che-machine-exec:${CHE_VERSION} 60
-# shellcheck disable=SC2086
-verifyContainerExistsWithTimeout ${REGISTRY}/${ORGANIZATION}/che-dashboard:${CHE_VERSION} 60
 # shellcheck disable=SC2086
 verifyContainerExistsWithTimeout ${REGISTRY}/${ORGANIZATION}/che-server:${CHE_VERSION} 60
 # shellcheck disable=SC2086
@@ -196,12 +193,16 @@ set +x
 if [[ ${PHASES} == *"2"* ]]; then
     releaseCheE2E
     releasePluginRegistry
+    releaseDashboard
 fi
 wait
 
 # shellcheck disable=SC2086
 verifyContainerExistsWithTimeout ${REGISTRY}/${ORGANIZATION}/che-e2e:${CHE_VERSION} 30
+# shellcheck disable=SC2086
 verifyContainerExistsWithTimeout ${REGISTRY}/${ORGANIZATION}/che-plugin-registry:${CHE_VERSION} 30
+# shellcheck disable=SC2086
+verifyContainerExistsWithTimeout ${REGISTRY}/${ORGANIZATION}/che-dashboard:${CHE_VERSION} 60
 # Release devfile registry (depends on plugin registry)
 if [[ ${PHASES} == *"3"* ]]; then
   releaseDevfileRegistry


### PR DESCRIPTION
Che Devworkspace Generator (here Generator) gets to be included in Che release cycle: https://github.com/eclipse/che/issues/22279

Generator is used in dashboard, e2e as package.json dependency, and in devfile registry itself during its release as an npm library. 
Generators sources are located in devfile registry in a subdirectory: https://github.com/eclipse-che/che-devfile-registry/tree/main/tools/devworkspace-generator

Right now, Generator is pinned everywhere to a fixed version.

Instead of placing the code for the release in existing devfile-registry release workflow, This PR will make use of a new GH workflow in devfile-registry, that performs ONLY release of Generator. Since devfile registry is already in one of the last phases of build, it would probably be better to release Generator first, and then get to release projects that depend on it as early as possible.

As another alternative solution, we can place devworkspace-generator in a repo of it's own, and invoke release workflow from there.
Linked PR: https://github.com/eclipse-che/che-devfile-registry/pull/751
