### PR TITLE
22407 - Remove Mattermost notification

### DIFF
--- a/.github/workflows/release-orchestrate-overall.yml
+++ b/.github/workflows/release-orchestrate-overall.yml
@@ -116,14 +116,14 @@ jobs:
           export CHE_INCUBATOR_BOT_GITHUB_TOKEN=${{ secrets.CHE_INCUBATOR_BOT_GITHUB_TOKEN }}
           set -e
           ./make-release.sh -v ${CHE_VERSION} -p ${PHASES} --parent-version ${PARENT_VERSION}
-      - name: Create failure MM message
-        if: ${{ failure() }}
-        run: |
-          echo "{\"text\":\":no_entry_sign: Che Release Orchestrator ${{ github.event.inputs.version }} has failed: https://github.com/eclipse-che/che-release/actions/workflows/release-orchestrate-overall.yml\"}" > mattermost.json
-      - name: Send MM message
-        if: ${{ failure() }}
-        uses: mattermost/action-mattermost-notify@1.1.0
-        env:
-          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
-          MATTERMOST_CHANNEL: eclipse-che-releases
-          MATTERMOST_USERNAME: che-bot
+      #- name: Create failure MM message
+        #if: ${{ failure() }}
+        #run: |
+          #echo "{\"text\":\":no_entry_sign: Che Release Orchestrator ${{ github.event.inputs.version }} has failed: https://github.com/eclipse-che/che-release/actions/workflows/release-orchestrate-overall.yml\"}" > mattermost.json
+      #- name: Send MM message
+        #if: ${{ failure() }}
+        #uses: mattermost/action-mattermost-notify@1.1.0
+        #env:
+          #MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+          #MATTERMOST_CHANNEL: eclipse-che-releases
+          #MATTERMOST_USERNAME: che-bot


### PR DESCRIPTION
eclipse/che#22407
Comment out the mattermost notification so it doesn't fail the release workflow, but leaving it in the file so I remember to replace it.