### PR TITLE
CRW-8590 Update traefik version to v3.3.5.

### DIFF
--- a/utils/copyImagesToQuay.txt
+++ b/utils/copyImagesToQuay.txt
@@ -14,7 +14,10 @@
 # docker.io/centos/postgresql-13-centos7:1
 
 # for Che 7.58
-docker.io/traefik:v2.9.6
+# docker.io/traefik:v2.9.6
+
+# for Che 7.102
+docker.io/traefik:v3.3.5
 
 # TODO: convince upstream owner to publish to quay.io instead; see https://github.com/eclipse/che-plugin-registry/pull/706
 # docker.io/dirigiblelabs/dirigible-openshift:3.4.0


### PR DESCRIPTION
Downstream can use go 1.23 now so we should update to the latest Traefik in both upstream and downstream.

https://issues.redhat.com/browse/CRW-8590